### PR TITLE
Make perl scripts independ of path

### DIFF
--- a/tools/3dump
+++ b/tools/3dump
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # Dump a binary PDP-7 file where a word is encoded as three bytes,
 # with sixbits are stored big-endian in each of the three byte.

--- a/tools/a7out
+++ b/tools/a7out
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # a7out: user-mode simulator for PDP-7 Unix applications
 #

--- a/tools/as7
+++ b/tools/as7
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # Read in files of PDP-7 assembly code in Ken Thompson's as format
 # and convert them into PDP-7 machine code

--- a/tools/ccov7
+++ b/tools/ccov7
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # Load a code coverage report from SimH and a kernel assembly listing
 # from as7, and show which lines in the kernel were not executed.

--- a/tools/fsck7
+++ b/tools/fsck7
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # fsck7: Check a PDP-7 filesystem for consistency
 #

--- a/tools/mkfs7
+++ b/tools/mkfs7
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # mkfs7: Make a PDP-7 filesystem image for SimH
 #

--- a/tools/sdump
+++ b/tools/sdump
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # sdump: Dump the contents of a filesystem in SimH format
 #

--- a/tools/xref7
+++ b/tools/xref7
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # Read in files of PDP-7 assembly code in Ken Thompson's as format
 # and output cross-reference and other details on the files.


### PR DESCRIPTION
Because of perl is not always /usr/bin/perl in *BSD or some other system, so we can put /usr/bin/env in front to make it builds.