### PR TITLE
Adding ttt1.s ttt2.s and un.s

### DIFF
--- a/scans/README.md
+++ b/scans/README.md
@@ -62,3 +62,6 @@ Details of the files:
 * space-travel-5.s pages 19-20 of 12-92-119.pdf
 * space-travel-6.s pages 21-25 of 12-92-119.pdf
 * space-travel-7.s pages 26-28 of 12-92-119.pdf
+* ttt1.s pages 1-12 of 14-148-165.pdf
+* ttt2.s pages 13-17 of 14-148-165.pdf
+* un.s page 18 of 14-148-165.pdf

--- a/scans/ttt1.s
+++ b/scans/ttt1.s
@@ -1,0 +1,714 @@
+" ttt1.s
+
+t = 0
+   lac 017777
+   tad d1
+   dac 9f+t
+   lac 9f+t i
+   sad qdt
+   skp
+   jmp loop
+   dac dspflg
+   law sbuf-1
+   dac blk1
+   dac blk2
+   jms dsboard
+   law dbuf
+   sys capt
+   law 16
+   sys syloc
+   tad d1
+   dac lpadr
+   law 13
+   sys sysloc
+   dac pbadr
+   dxm lpadr i
+loop:
+   jms move
+   jms must; jmp loop
+   lac imaxin
+   dac maxin
+   law stack-1
+   dac 10
+   jms try; jmp unwind
+   jmp heur; jmp loop
+
+unwind:
+   lac 12
+   dac 9f+t
+1:
+   lac 9f+t i
+   jms mark; 1
+   -1
+   tad 9f+t
+   dac 9f+t
+   lac 9f+t i
+   spa
+   jmp done
+   jms mark; 512
+   -1
+   tad 9f+t
+   dac 9f+t
+   lac dspflg
+   sna
+   jmp 1b
+   jms getpb
+   sza
+   jmp .-2
+   jms getpb
+   sna
+   jmp .-2
+   jmp 1b
+t = t+1
+
+move: 0
+   lac dspflg
+   sza
+   jmp dspmove
+   jms messg; m>;>o>;v>;e>;0
+   dzm 9f+t
+1:
+   jms getc
+   sad o12
+   jmp 1f
+   tad om60
+   spa
+   jmp move+1
+   dac 9f+t+1
+   and o3
+   sad 9f+t+1
+   skp
+   jmp move+1
+   lac 9f+t
+   alss 2
+   xor 9f+t+1
+   dac 9f+t
+   jmp 1b
+1:
+   lac 9f+t
+   spa
+   jmp move+1
+   and o77
+   sad 9f+t
+   skp
+   jmp move+1
+   tad boardp
+   dac 9f+t
+   lac 9f+t i
+   sza
+   jmp move+1
+   lac 9f+t
+   jms mark; 512
+   jmp move i
+
+dsmove:
+   jms getpb
+   sza
+   jmp pbhit
+   lac lpadr i
+   sna
+   jmp dspmove
+
+lphit:
+   lmq
+   lac blink
+   sna
+   jmp 1f
+   cma
+   tad boardp
+   cma
+   alss 4
+   tad sbufp
+   dac 9f+t
+   lac noblink
+   dac blk1 i
+   dac blk2 i
+   dac 9f+t i
+1:
+   dzm lpaddr i
+   lacq
+   cma
+   tad sbufp
+   cma
+   lrss 4
+   dac 9f+t
+   and o77
+   sad 9f+t
+   skp
+   jmp dspmove
+   tad boardp
+   dac blink
+   lac 9f+t
+   alss 4
+   tad sbufp
+   dac 9f+t
+   lac blinkpar
+   dac 9f+t i
+   jmp dspmove
+
+pbhit:
+   lac blink
+   sna
+   jmp dspmove
+   jms mark; 512
+   dzm blink
+   jmp move i
+t = t+2
+
+must: 0
+
+" check for 3g,4g,4b
+
+   law line-1
+   dac 8
+   -76
+   dac 9f+t
+   dzm 9f+t+1
+   dzm 9f+t+2
+1:
+   cla
+   xct 8 i
+   xct 8 i
+   xct 8 i
+   xct 8 i
+   sad o4
+   jmp done
+   sad o4000
+   jmp done
+   sad o3
+   dac 9f+t+2
+   sad o3000
+   skp
+   jmp 2f
+   -4
+   tad 8
+   dac 9
+   cla
+   xct 9 i
+   sza cla
+   jmp .-2
+   -1
+   tad 9
+   dac 9
+   lac 9 i
+   dac 9f+t+1
+2:
+   isz 9f+t
+   jmp 1b
+   lac 9f+t+2
+   sza
+   jmp 1f
+   lac 9f+t+1
+   sna
+   jmp 1f
+   jms mark; 1
+   jmp must i
+1:
+   isz must
+   jmp must i
+t = t+3
+
+done:
+   lac dspflg
+   sza
+   jmp 1f
+   jms messg; e>;x>;i>;t>;0
+   sys exit
+1:
+   law sbuf-1
+   dac blk1
+   dac blk2
+   jms dsboard
+   law line-1
+   dac 8
+   -76
+   dac 9f+t
+1:
+   cla
+   xct 8 i
+   xct 8 i
+   xct 8 i
+   xct 8 i
+   sad o4
+   jmp 1f
+   sad o4000
+   jmp 1f
+   isz 9f+t
+   jmp 1b
+   sys exit
+1:
+   -4
+   tad 8
+   dac 9
+1:
+   lac 9 i
+   cma
+   tad boardp
+   cma
+   alss 4
+   tad sbufp
+   dac 9f+t
+   lac blinkpar
+   dac 9f+t i
+   lac 8
+   sad 9
+   skp
+   jmp 1b
+   jms getpb
+   sza
+   jmp .-2
+   jms getpb
+   sna
+   jmp .-2
+   sys exit
+t = t+1
+
+mark: 0
+   dac 9f+t
+   lac mark i
+   dac 9f+t i
+   isz mark
+   lac dspflg
+   sna
+   jmp 1f
+   lac blk1
+   dac blk2
+   lac 9f+t
+   cma
+   tad boardp
+   cma
+   alss 4
+   tad sbufp
+   dac blk1
+   jms dsboard
+   jmp mark i
+1:
+   lac 9f+t i
+   sad d1
+   skp
+   jmp mark i
+   lac 9f+t
+   cma
+   tad boardp
+   cma
+   dac 9f+t
+   lrs 4
+   and o3
+   tad o60
+   dac 0f
+   lac 9f+t
+   lrs 2
+   and o3
+   tad o60
+   dac 0f+1
+   lac 9f+t
+   and o2
+   tad o60
+   dac 0f+2
+   jms messg; 0:0;0;0;0
+   jmp mark i
+t = t+1
+
+try: 0
+
+" check 3g or 3b
+
+   law line-1
+   dac 9
+   -76
+   dac 9f+t+3
+   dzm 9f+t+4
+1:
+   cla
+   xct 9 i
+   xct 9 i
+   xct 9 i
+   xct 9 i
+   sad o3000
+   dac 9f+t+4
+   sad o3
+   skp
+   jmp 2f
+   lac 10
+   dac 12
+   -1
+   dac 12 i
+   -4
+   tad 9
+   dac 9
+   cla
+   xct 9 i
+   sza cla
+   jmp .-2
+   -1
+   tad 9
+   dac 9
+   lac 9 i
+   dac 12 i
+   lac dspflg
+   sza
+   jmp try i
+   jms messg; i>;040;w>;i>;n>;0
+   jmp try i
+2:
+   isz 9f+t+3
+   jmp 1b
+   lac 9f+t+4
+   sna
+   jmp 1f
+   lsz try
+   jmp try i
+
+" save
+
+1:
+   isz maxin
+   jmp 1f
+   -1
+   dac maxin
+   isz try
+   jmp try i
+1:
+   lac try
+   dac 10 i
+   lac 8
+   dac 10 i
+   lac 9f+t
+   dac 10 i
+   lac 9f+t+1
+   dac 10 i
+   lac 9f+t+2
+   dac 10 i
+
+" check 2g
+
+   law line-1
+   dac 8
+   -76
+   dac 9f+t
+1:
+   cla
+   xct 8 i
+   xct 8 i
+   xct 8 i
+   xct 8 i
+   sad o2
+   skp
+   jmp 2f
+   -4
+   tad 8
+   dac 9
+   cla
+   xct 9 i
+   sza cla
+   jmp .-2
+   lac 9
+   dac 9f+t+1
+   lac 9f+t+1 i
+   dac 9f+t+1
+   cla
+   xct 9 i
+   sza cla
+   jmp .-2
+   lac 9
+   dac 9f+t+2
+   lac 9f+t+2 i
+   dac 9f+t+2
+
+" recurse
+
+   lac d1
+   dac 9f+t+1 i
+   lac o1000
+   dac 9f+t+2 i
+   jms try; jmp prnt
+   lac d1
+   dac 9f+t+2 i
+   lac o1000
+   dac 9f+t+1 i
+   jms try; jmp prnt
+   dzm 9f+t+1 i
+   dzm 9f+t+2 i
+2:
+   isz 9f+t
+   jmp 1b
+
+" restore
+   
+   -5
+   tad 10
+   dac 10
+   dac 9
+   lac 9 i
+   dac try
+   lac 9 i
+   dac 8
+   lac 9 i
+   dac 9f+t
+   lac 9 i
+   dac 9f+t+1
+   lac 9 i
+   dac 9f+t+2
+   isz try
+   jmp try i
+
+prnt:
+   lac 9f+t+1 i
+   sad d1
+   jmp 1f
+   lac 9f+t+1
+   dac 12 i
+   lac 9f+t+2
+   jmp 2f
+1:
+   lac 9f+t+2
+   dac 12 i
+   lac 9f+t+1
+2:
+   dac 12 i
+   dzm 9f+t+1 i
+   dzm 9f+t+2 i
+   -5
+   tad 10
+   dac 10
+   dac 9
+   lac 9 i
+   dac try
+   lac 9 i
+   dac 8
+   lac 9 i
+   dac 9f+t
+   lac 9 i
+   dac 9f+t+1
+   lac 9 i
+   dac 9f+t+2
+   jmp try i
+t = t+5
+
+heur: 0
+   jms addpri
+   -2
+   tad force
+   dac lforce
+   -1000
+   dac lrpi
+   -64
+   dac 9f+t
+   lac boardp
+   dac 9f+t+1
+1:
+   lac 9f+t+1 i
+   sza
+   jmp 3f
+   lac d1
+   dac 9f+t+1 i
+   jms addpri
+   lac force
+   sad lforce
+   jmp 4f
+   lac pri
+   cma
+   tad lrpi
+   sma cma
+   jmp 3f-1
+   sza
+   jmp 2f
+   isz prob
+   -1
+   cll; idiv; prob;.,
+   lacq
+   lrss 6
+   dac force
+   sys time
+   lacq
+   tad rand
+   cll; mul; 37111
+   lacq
+   dac rand
+   cll; lrs 6
+   cma
+   tad force
+   spa
+   jmp 3f-1
+   jmp 2f+2
+2:
+   lac d1
+   dac prob
+   lac pri
+   dac lpri
+   lac 9f+t+1
+   dac lmov
+   dzm 9f+t+1 i
+3:
+   isz 9f+t+1
+   isz 9f+t
+   jmp 1b
+   lac lmov
+   jms mark; 1
+   jmp heiur i
+4:
+   lac 9f+t+1
+   jsm mark; 1
+   jmp heur i
+t = t+2
+   
+addpri: 0
+   clq
+   law line-1
+   dac 8
+   -76
+   dac 9f+t
+   dzm force
+1:
+   cla
+   xct 8 i
+   xct 8 i
+   xct 8 i
+   xct 8 i
+   sad o2000
+   isz force
+   dac 9f+t+1
+   rtr;rtr;rtr;rar
+   xor 9f+t+1
+   and o77
+   tad 2f
+   dac .+2
+   lacq
+   tad ..
+   lmq
+   isz 9f+t
+   jmp 1b
+   law plane-1
+   dac 8
+   -18
+   dac 9f+t
+1:
+   -16
+   dac 9f+t+1
+   cla
+0:
+   xct 8 i
+   isz 9f+t+1
+   jmp 0b
+pstrat:
+   jms 3f; 04002; 1
+   jms 3f; 03001; 15
+   jms 3f; 04001; 20
+   jms 3f; 1; 1
+   isz 9f+t
+   jmp 1b
+   lacq
+   dac pri
+   jmp addpri i
+2: tad pritab
+3: 0
+   sad 3b i
+   jmp 1f
+   isz 3b
+   isz 3b
+   jmp 3b i
+1:
+   isz 3b
+   lacq
+   tad 3b i
+   lmq
+   cla
+   isz 3b
+   jmp 3b i
+t = t+2
+
+dsboard: 0
+   -64
+   dac 9f+t
+   dzm 9f+t+2
+   dac 8
+   law sbuf-1
+   dac 11
+
+8:
+   lac noblink
+   dac 11
+   lac 9f+t+2
+   and o3
+   alss 6
+   dac 9f+t+3
+   alss 1
+   tad 9f+t+3
+   dac 9f+t+3
+   lac 9f+t+2
+   and o14
+   alss 4
+   tad 9f+t+3
+   xor setxv
+   dac 11 i
+   lac 9f+t+2
+   and o74
+   alss 4
+   xor setyv
+   dac 11 i
+   lac 8 i
+   sna
+   jmp 4f
+   sad d1
+   jmp 3f
+   law ex-1
+   jmp 2f
+3: law oh-1
+   jmp 2f
+4: law dot-1
+2: dac 9
+   -12
+   dac 9f+t+1
+1:
+   lac 9 i
+   dac 11 i
+   isz 9f+t+1
+   jmp 1
+   lac noblink
+   dac 11 i
+   isz 9f+t+2
+   isz 9f+t
+   jmp 8b
+   -1
+   dac 11i
+   lac blinkpar
+   dac blk1 i
+   dac blk2 i
+   jmp dsboard i
+t = t+4
+
+getc: 0
+   cla
+   sys read; 9f+t; 1
+   sna spa
+   sys save
+   lac 9f+t
+   lrss 9
+   jmp getc i
+
+messg: 0
+   -1
+   tad messg
+   dac 9
+1:
+   lac 9 i
+   sna
+   jmp 1f
+   dac 9f+t
+   lac d1
+   sys write; 9f+t; 1
+   jmp 1b
+1:
+   lac d1
+   sys write; o12; 1
+   jmp 9 i
+t = t+1
+
+getpb: 0
+   sys time
+   lac pbar i
+   and o2000
+   sza
+   sys exit
+   lac pbadr i
+   jmp getpb i

--- a/scans/ttt2.s
+++ b/scans/ttt2.s
@@ -1,0 +1,271 @@
+" ttt2
+
+boardp: board
+shufp: sbuf
+qdt: <dt>
+imaxin: -4000
+noblink: 060000
+blinkpar: 070000
+setxy: setx
+setyv: sety
+o12: 012
+o14: 014
+o74: 074
+o3: 03
+o2000: 02000
+o60: o60
+o4: 4
+o3000: 03000
+o4000: 04000
+o2: 2
+o1000: 01000
+d1: 1
+dm60: -060
+o77: 077
+line:
+tb = tad board-1
+   tb+52; tb+56; tb+60; tb+64
+   tb+1; tb+6; tb+11; tb+16
+   tb+2; tb+6; tb+10; tb+14
+   tb+2; tb+18; tb+34; tb+50
+   tb+2; tb+22; tb+42; tb+62
+   tb+3; tb+7; tb+11; tb+15
+   tb+3; tb+23; tb+43; tb+63
+   tb+3; tb+19; tb+35; tb+51
+   tb+4; tb+7; tb+10; tb+13
+   tb+4; tb+8; tb+12; tb+16
+   tb+4; tb+19; tb+34; tb+49
+   tb+4; tb+20; tb+36; tb+52
+   tb+4; tb+23; tb+42; tb+61
+   tb+61; tb+62; tb+63; tb+64
+   tb+4; tb+24; tb+44; tb+64
+   tb+5; tb+6; tb+7; tb+8
+   tb+5; tb+21; tb+37; tb+53
+   tb+5; tb+22; tb+39; tb+56
+   tb+6; tb+22; tb+38; tb+54
+   tb+7; tb+23; tb+39; tb+55
+   tb+8; tb+23; tb+38; tb+53
+   tb+8; tb+24; tb+40; tb+56
+   tb+9; tb+10; tb+11; tb+12
+   tb+9; tb+26; tb+43; tb+60
+   tb+9; tb+25; tb+41; tb+57
+   tb+12; tb+28; tb+44; tb+60
+   tb+13; tb+14; tb+15; tb+16
+   tb+13; tb+25; tb+37; tb+49
+   tb+13; tb+26; tb+39; tb+52
+   tb+13; tb+29; tb+45; tb+61
+   tb+13; tb+30; tb+47; tb+64
+   tb+14; tb+26; tb+38; tb+50
+   tb+14; tb+30; tb+46; tb+62
+   tb+15; tb+27; tb+39; tb+51
+   tb+53; tb+54; tb+55; tb+56
+   tb+13; tb+31; tb+47; tb+63
+   tb+16; tb+28; tb+40; tb+52
+   tb+16; tb+27; tb+38; tb+49
+   tb+16; tb+31; tb+46; tb+61
+   tb+16; tb+32; tb+48; tb+64
+   tb+17; tb+21; tb+25; tb+29
+   tb+17; tb+18; tb+19; tb+20
+   tb+17; tb+22; tb+27; tb+32
+   tb+18; tb+22; tb+26; tb+30
+   tb+19; tb+23; tb+27; tb+31
+   tb+20; tb+23; tb+26; tb+29
+   tb+20; tb+24; tb+28; tb+32
+   tb+21; tb+22; tb+23; tb+24
+   tb+25; tb+26; tb+27; tb+28
+   tb+29; tb+30; tb+31; tb+32
+   tb+33; tb+34; tb+35; tb+36
+   tb+33; tb+38; tb+43; tb+48
+   tb+33; tb+37; tb+41; tb+45
+   tb+34; tb+38; tb+42; tb+46
+   tb+35; tb+39; tb+43; tb+47
+   tb+36; tb+39; tb+42; tb+45
+   tb+36; tb+40; tb+44; tb+48
+   tb+37; tb+38; tb+39; tb+40
+   tb+41; tb+42; tb+43; tb+44
+   tb+45; tb+46; tb+47; tb+48
+   tb+49; tb+50; tb+51; tb+52
+   tb+49; tb+53; tb+57; tb+61
+   tb+12; tb+27; tb+42; tb+57
+   tb+49; tb+54; tb+59; tb+64
+   tb+50; tb+54; tb+58; tb+62
+   tb+51; tb+55; tb+59; tb+63
+   tb+52; tb+55; tb+58; tb+61
+   tb+57; tb+58; tb+59; tb+60
+   tb+11; tb+27; tb+43; tb+59
+   tb+10; tb+26; tb+42; tb+58
+   tb+1; tb+2; tb+3; tb+4
+   tb+1; tb+5; tb+9; tb+13
+   tb+1; tb+17; tb+33; tb+49
+   tb+1; tb+18; tb+35; 52
+   tb+1; tb+21; tb+41; tb+61
+   tb+1; tb+22; tb+43; tb+64
+plane:
+   tb+1; tb+2; tb+3; tb+4; tb+5; tb+6; tb+7; tb+8
+   tb+9; tb+10; tb+11; tb+12; tb+13; tb+14; tb+15; tb+16
+
+   tb+17; tb+18; tb+19; tb+20; tb+21; tb+22; tb+23; tb+24
+   tb+25; tb+26; tb+27; tb+28; tb+29; tb+30; tb+31; tb+32
+
+   tb+33; tb+34; tb+35; tb+36; tb+37; tb+38; tb+39; tb+40
+   tb+41; tb+42; tb+43; tb+44; tb+45; tb+46; tb+47; tb+48
+
+   tb+49; tb+50; tb+51; tb+52; tb+53; tb+54; tb+55; tb+56
+   tb+57; tb+58; tb+59; tb+60; tb+61; tb+62; tb+63; tb+64
+
+   tb+13; tb+14; tb+15; tb+16; tb+29; tb+30; tb+31; tb+32
+   tb+45; tb+46; tb+47; tb+48; tb+91; tb+62; tb+63; tb+64
+
+   tb+9; tb+10; tb+11; tb+12; tb+25; tb+26; tb+27; tb+28
+   tb+41; tb+42; tb+43; tb+44; tb+57; tb+58; tb+59; tb+60
+
+   tb+5; tb+6; tb+7; tb+8; tb+21; tb+22; tb+23; tb+24
+   tb+37; tb+38; tb+39; tb+40; tb+53; tb+54; tb+55; tb+56
+
+   tb+1; tb+2; tb+3; tb+4; tb+17; tb+18; tb+19; tb+20
+   tb+33; tb+34; tb+35; tb+36; tb+49; tb+50; tb+51; tb+52
+
+   tb+1; tb+5; tb+9; tb+13; tb+17; tb+21; tb+25; tb+29
+   tb+33; tb+37; tb+41; tb+45; tb+49; tb+53; tb+57; tb+61
+
+   tb+2; tb+6; tb+10; tb+14; tb+18; tb+22; tb+26; tb+30
+   tb+34; tb+38; tb+42; tb+46; tb+50; tb+54; tb+58; tb+62
+
+
+   tb+3; tb+7; tb+11; tb+15; tb+19; tb+23; tb+27; tb+31
+   tb+35; tb+39; tb+43; tb+47; tb+51; tb+55; tb+59; tb+63
+
+   tb+4; tb+8; tb+12; tb+16; tb+20; tb+24; tb+28; tb+32
+   tb+36; tb+40; tb+44; tb+48; tb+52; tb+56; tb+60; tb+64
+
+   tb+1; tb+6; tb+11; tb+16; tb+17; tb+22; tb+27; tb+32
+   tb+33; tb+38; tb+43; tb+48; tb+49; tb+54; tb+59; tb+64
+
+   tb+4; tb+7; tb+10; tb+13; tb+20; tb+23; tb+26; tb+29
+   tb+35; tb+39; tb+42; tb+45; tb+52; tb+55; tb+58; tb+62
+
+   tb+1; tb+2; tb+3; tb+4; tb+21; tb+22; tb+23; tb+24
+   tb+41; tb+42; tb+43; tb+44; tb+61; tb+62; tb+63; tb+67
+
+   tb+13; tb+14; tb+15; tb+16; tb+25; tb+26; tb+27; tb+28
+   tb+37; tb+38; tb+39; tb+40; tb+39; tb+50; tb+51; tb+52
+
+   tb+1; tb+5; tb+9; tb+13; tb+18; tb+22; tb+26; tb+30
+   tb+35; tb+39; tb+43; tb+47; tb+52; tb+56; tb+60; tb+64
+
+   tb+4; tb+8; tb+12; tb+16; tb+19; tb+23; tb+27; tb+31
+   tb+34; tb+38; tb+42; tb+46; tb+49; tb+53; tb+57; tb+61
+pritab:
+   0;10;22;0
+   0;10;20;0
+   0;30;30;0
+   0;0;0;0;0
+ex:
+   vx 0100
+   vy 020 iv
+   vx 0200
+   vy 040 v
+   vx m 0140
+   vy 0 iv
+   vx 0100
+   vy m 040 v
+   dnop
+   dnop
+   dnop
+   dnop
+oh:
+   vx 0100
+   vy020 iv
+   vx0140
+   vy 0 v
+   vx 040
+   vy 040 v
+   vx m 0140
+   vy 0 v
+   vx m 040
+   vy m 040 v
+   dnop
+   dnop
+dot:
+   ipenb
+   vx 0200
+   vy 040 iv
+   vx 05
+   vy 0 v
+   vx 0
+   vy m 05 v
+   vx m 05
+   vy 0 v
+   vx 0
+   vy 05 v
+   lpdis
+dbuf:
+   lpdis
+   scale 0
+   setx 0
+   sety 0
+   "
+   vx 01400 v
+   vx 0377
+   vy 0374 v
+   vx m 01377 v
+   vx m 0400
+   vy m 0374 v
+   "
+   setx 0
+   sety 0400
+   vx 01400 v
+   vx 0377
+   vy 0374 v
+   vx m 01377 v
+   vx m 0400
+   vy m 0374 v
+   "
+   setx 0
+   sety 01000
+   vx 01400 v
+   vx 0377
+   vy 0374 v
+   vx m 01377 v
+   vx m 0400
+   vy m 0374 v
+   "
+   setx 0
+   sety 01400
+   vx 01400 v
+   vx 0377
+   vy 0374 v
+   vx m 01377 v
+   vx m 0400
+   vy m 0374 v
+   dnop
+sbuf: .=.+1050
+board: .=.+64
+maxin: .=.+1
+force: .=.+1
+pri: .=.+1
+lpri: .=.+1
+lforce: .=.+1
+rand: .=.+1
+lmov: .=.+1
+dspflg: .=.+1
+lpadr: .=.+1
+pbadr: .=.+1
+blink: .=.+1
+blk1: .=.+1
+blk2: .=.+1
+9: .=.+1
+stack:
+
+dnop = 040040
+setx = 0140000
+sety = 0164000
+n = 02000
+scale = 0040040
+y = 020000
+iy = 030000
+vx = 0100000
+vy = 0104000
+lpdis = 0044000
+lpenb = 0046000
+vbl = 0704424

--- a/scans/un.s
+++ b/scans/un.s
@@ -1,0 +1,48 @@
+" un
+
+   sys open; n.out; 0
+   spa
+   jmp error
+   sys read; buf; 3072
+   cll; idiv; 6
+   lacq; cma; tad d1
+   dac c1
+1:
+   lac t1
+   tad d4
+   dac t2
+   lac i t2
+   sad d3
+   skp
+   jmp 2f
+   lac d1
+   sys write; t1; buf; 4
+   lac d1
+   sys write; mes+1; 1
+2:
+   lac t1
+   tad d6
+   dac t1
+   isz ca1
+   jmp 1b
+
+   sys exit
+
+error:
+   lac d1
+   sys write; mes; 2
+   sys exit
+
+mes:
+   077; 012
+n.out:
+   <n.>;<ou>;<t 040; 0400040
+
+d1: 1
+d6: 6
+d3: 3
+c1: 0
+t2: 0
+d4: 4
+
+buf:


### PR DESCRIPTION
I'm making another attempt with `ttt1.s`, `ttt2.s` and `un.s` which have not [been reserved](https://minnie.tuhs.org/pipermail/pdp7-unix/2019-October/000491.html).

As with the previous pull request I'm happy to collaborate or use my proposals only to verify others' transcriptions. :)