### PR TITLE
Fix a number of typos in ttt1.s and ttt.2

### DIFF
--- a/scans/ttt1.s
+++ b/scans/ttt1.s
@@ -32,7 +32,7 @@ loop:
    law stack-1
    dac 10
    jms try; jmp unwind
-   jmp heur; jmp loop
+   jms heur; jmp loop
 
 unwind:
    lac 12
@@ -67,7 +67,7 @@ move: 0
    lac dspflg
    sza
    jmp dspmove
-   jms messg; m>;>o>;v>;e>;0
+   jms messg; m>;o>;v>;e>;0
    dzm 9f+t
 1:
    jms getc
@@ -160,7 +160,7 @@ t = t+2
 
 must: 0
 
-" check for 3g,4g,4b
+" check for 3g.4g.4b
 
    law line-1
    dac 8
@@ -307,7 +307,7 @@ mark: 0
    tad o60
    dac 0f+1
    lac 9f+t
-   and o2
+   and o3
    tad o60
 "** 14-148-165.pdf page 6
    dac 0f+2
@@ -632,13 +632,14 @@ dsboard: 0
    -64
    dac 9f+t
    dzm 9f+t+2
+   law board-1
    dac 8
    law sbuf-1
    dac 11
 
 8:
    lac noblink
-   dac 11
+   dac 11 i
    lac 9f+t+2
    and o3
    alss 6
@@ -674,7 +675,7 @@ dsboard: 0
    lac 9 i
    dac 11 i
    isz 9f+t+1
-   jmp 1
+   jmp 1b
    lac noblink
    dac 11 i
    isz 9f+t+2

--- a/scans/ttt2.s
+++ b/scans/ttt2.s
@@ -14,7 +14,7 @@ o14: 014
 o74: 074
 o3: 03
 o2000: 02000
-o60: o60
+o60: 060
 o4: 4
 o3000: 03000
 o4000: 04000
@@ -99,7 +99,7 @@ tb = tad board-1
    tb+1; tb+2; tb+3; tb+4
    tb+1; tb+5; tb+9; tb+13
    tb+1; tb+17; tb+33; tb+49
-   tb+1; tb+18; tb+35; 52
+   tb+1; tb+18; tb+35; tb+52
    tb+1; tb+21; tb+41; tb+61
    tb+1; tb+22; tb+43; tb+64
 plane:
@@ -116,14 +116,13 @@ plane:
    tb+57; tb+58; tb+59; tb+60; tb+61; tb+62; tb+63; tb+64
 
    tb+13; tb+14; tb+15; tb+16; tb+29; tb+30; tb+31; tb+32
-   tb+45; tb+46; tb+47; tb+48; tb+91; tb+62; tb+63; tb+64
+   tb+45; tb+46; tb+47; tb+48; tb+61; tb+62; tb+63; tb+64
 
    tb+9; tb+10; tb+11; tb+12; tb+25; tb+26; tb+27; tb+28
    tb+41; tb+42; tb+43; tb+44; tb+57; tb+58; tb+59; tb+60
 
    tb+5; tb+6; tb+7; tb+8; tb+21; tb+22; tb+23; tb+24
    tb+37; tb+38; tb+39; tb+40; tb+53; tb+54; tb+55; tb+56
-
 "** 14-148-165.pdf page 15
    tb+1; tb+2; tb+3; tb+4; tb+17; tb+18; tb+19; tb+20
    tb+33; tb+34; tb+35; tb+36; tb+49; tb+50; tb+51; tb+52
@@ -148,7 +147,7 @@ plane:
    tb+35; tb+39; tb+42; tb+45; tb+52; tb+55; tb+58; tb+62
 
    tb+1; tb+2; tb+3; tb+4; tb+21; tb+22; tb+23; tb+24
-   tb+41; tb+42; tb+43; tb+44; tb+61; tb+62; tb+63; tb+67
+   tb+41; tb+42; tb+43; tb+44; tb+61; tb+62; tb+63; tb+64
 
    tb+13; tb+14; tb+15; tb+16; tb+25; tb+26; tb+27; tb+28
    tb+37; tb+38; tb+39; tb+40; tb+39; tb+50; tb+51; tb+52
@@ -265,10 +264,10 @@ stack:
 dnop = 040040
 setx = 0140000
 sety = 0164000
-n = 02000
+m = 02000
 scale = 0040040
-y = 020000
-iy = 030000
+v = 020000
+iv = 030000
 vx = 0100000
 vy = 0104000
 lpdis = 0044000


### PR DESCRIPTION
With this ttt1.s and ttt2.s compiles cleanly:

```
$ ./tools/as7 --out ttt scans/ttt1.s scans/ttt2.s 
I
II
scans/ttt1.s
scans/ttt2.s
$
```

I took the liberty of submitting these together since the pair comprise the `ttt` binary.