### PR TITLE
two mkfs7 changes (.. and link to inum -1), make hard link for list program

### DIFF
--- a/build/proto
+++ b/build/proto
@@ -61,9 +61,9 @@ dd           drwr- -1 4
 
         nsh      frwr- -1 bin/nsh
         nls      frwr- -1 bin/nls
+	list     l---- -1
 #       nbc      frwr- -1 bin/nbc
         nstat    frwr- -1 bin/nstat
-
 
 
   $

--- a/tools/mkfs7
+++ b/tools/mkfs7
@@ -62,6 +62,7 @@ my $nextinum   = 1;	# i-num 0 is never used
 my @Dirstack;	# Stack of directories. Each value is a ref
                 # to a [ blocknum, offset, inum ] array which
                 # is the next free position in the directory
+my $lastinum   = -1;	# last inum assigned, for link to i-num -1
 
 # Debug printing
 sub dprint {
@@ -277,6 +278,8 @@ sub add_block_to_inode {
 sub add_direntry {
     my ( $name, $inum ) = @_;
 
+    $inum = $lastinum if ($inum == -1);
+
     # Get the block and offset to the next empty slot in the directory
     my $dirref = $Dirstack[-1];
 
@@ -320,6 +323,7 @@ sub add_direntry {
 
     # Finally, increment the link count
     increment_link_count($inum);
+    $lastinum = $inum;
 }
 
 # Given a name, perms, a user-id and an optional i-node number, make a
@@ -360,8 +364,11 @@ sub make_dir {
     if (!$no_dd) {
       add_direntry( "dd", $Dirstack[0]->[2] );
       dprintf("Added a dd entry to i-num %d\n", $Dirstack[0]->[2] );
+      if (!$wantdotdot && !$wantdot) {	# PLB 2019
+	add_direntry( "..", $inum );
+	dprint("Added a .. entry to ourselves\n");
+      }
     }
-
     dprintf( "Made directory %s perms %06o uid %d in inum %d\n\n",
         $dirname, $perms, $uid, $inum );
 }


### PR DESCRIPTION
mkfs: if neither --dotdot or --dot options given, create .. link to current dir
      accept -1 for inum in add_direntry to mean "use previous i-num" for links

@DoctorWkt demo of new (original) shell and ls programs with ".." link for current dir.
"list" is a link to nls.

proto: use inum -1 to make "list" a link to "nls"

```
phil@p27:~/pdp7-unix/build$ echo ../../simh/BIN/pdp7 unixv0.simh > run
phil@p27:~/pdp7-unix/build$ sh run

PDP-7 simulator V4.0-0 Current        git commit id: 155245c1
CPU	idle disabled
	8KW, EAE
/home/phil/pdp7-unix/build/unixv0.simh-13> att rb image.fs
RB: buffering file in memory
/home/phil/pdp7-unix/build/unixv0.simh-18> att -U g2in 12345
Listening on port 12345
PDP-7 simulator configuration

CPU	idle disabled
CLK	60Hz, devno=00
PTR	devno=01
PTP	devno=02
TTI	devno=03
TTO	devno=04
LPT	disabled
DRM	disabled
RB	devno=71
DT	disabled
G2OUT	devno=05
G2IN	devno=43-44

login: system
password: system
# nsh
@ nls
..
apr
as
bc
cas
cat
check
chmod
chown
chrm
cp
date
db
dd
display
ds
dskres
dsksav
dsw
ed
init
keyboard
list
ln
ls
lsd
lsl
moo
mv
nls
nm
nsh
nstat
od
p
password
pd
pptin
pptout
rm
rn
roff
salv
sh
stat
tm
ttyin
ttyout
@ ch dd
@ nls
..
core
dd
dmr
ken
system
@ ch ken
@ nls
..
dd
maksys.s
s1.s
s2.s
s3.s
s4.s
s5.s
s6.s
s7.s
s8.s
sop.s
system
sys.rc
trysys.s
@ nsh <  sys.rc > sys.out
@ list
065 36 12 02 00250 ..
116 17 77 01 05767 a.out
004 36 77 05 00070 dd
077 16 12 01 00660 maksys.s
113 17 77 01 00116 maksys
114 17 77 01 05134 n.out
067 16 12 01 06011 s1.s
070 16 12 01 12624 s2.s
071 16 12 01 07761 s3.s
072 16 12 01 12377 s4.s
073 16 12 01 07750 s5.s
074 16 12 01 11713 s6.s
075 16 12 01 11160 s7.s
076 16 12 01 06435 s8.s
066 16 12 01 03505 sop.s
003 36 77 04 00600 system
101 16 12 01 00131 sys.rc
112 17 77 01 00070 sys.out
100 16 12 01 00312 trysys.s
115 17 77 01 00050 trysys
@ cat sys.out
@ @ @ @ @ @ @ @ @ II
sop.s   
s1.s    
s2.s    
s3.s    
s4.s    
s5.s    
s6.s    
s7.s    
s8.s    
@ trysys

login:
```