### PR TITLE
Move typo correction from scans/st4.s to src/cmd/st4.s.

### DIFF
--- a/scans/st4.s
+++ b/scans/st4.s
@@ -164,7 +164,7 @@ surf: 0
 	jmp i surf
 
 drcirc: 0
-	lac grvflg
+	lac crvflg
 	spa
 	jmp i drcirc
 	lac fcplan

--- a/src/cmd/st4.s
+++ b/src/cmd/st4.s
@@ -164,7 +164,9 @@ surf: 0
 	jmp i surf
 
 drcirc: 0
-	lac grvflg
+	lac grvflg	" looks like lac crvflg in scan, but
+			" crvflg is never defined, but grvflg is defined
+			" therefore change this to grvflg
 	spa
 	jmp i drcirc
 	lac fcplan


### PR DESCRIPTION
This is a typo in the scan itself, and so the correction should not
be in scans/st4.s, but in src/cmd/st4.s along with a comment
explaining why is was changed. This is addressed by this commit.