### PR TITLE
Novell -> Micro Focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ tm
 
 ## Source Tree
 
-The code in the original scans are (c) Novell who own the rights to the Unix
+The code in the original scans are (c) Micro Focus who own the rights to the Unix
 source code. Everything that didn't come from the scanned files is GPLv3.
 
 * /build     is an area to build the kernel & filesystem and run them

--- a/scans/README.md
+++ b/scans/README.md
@@ -8,8 +8,8 @@ https://www.tuhs.org/Archive/Distributions/Research/McIlroy_v0/
 
 The files should be unaltered versions of the scanned pages.
 
-Novell owns the rights to the Unix source code, so these files are probably
-(c) 1970 Novell. They are certainly not under the GPLv3 license.
+Micro Focus owns the rights to the Unix source code, so these files are probably
+(c) 1970 Micro Focus. They are certainly not under the GPLv3 license.
 
 For modified versions of these files, look in src/cmds and src/sys.
 


### PR DESCRIPTION
Novell was acquired by Attachmate in 2011;
Attachmate was acquired by Micro Focus in 2014.

This makes Micro Focus the current copyright holder.

I've been unable to determine which legal entity inside Micro Focus is the copyright holder, but what is clear is that Novell and therefore all their copyrights are owned by them now. (They seem to be very hellbent on ignoring that their UNIX copyright even exists, however.)