### PR TITLE
Space Travel now runs without crashing after reordering input files.

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -138,6 +138,7 @@ cmd:	dirs \
 	$(BINDIR)/roff \
 	$(BINDIR)/salv \
 	$(BINDIR)/sh \
+	$(BINDIR)/st \
 	$(BINDIR)/stat \
 	$(BINDIR)/tm \
 	$(BINDIR)/ttt \
@@ -253,6 +254,10 @@ $(BINDIR)/tm: $(CMDSRC)/tm.s
 TTT=$(CMDSRC)/ttt1.s $(CMDSRC)/ttt2.s
 $(BINDIR)/ttt: $(TTT)
 	$(AS) $(ASARGS) -o $(BINDIR)/ttt $(TTT)
+
+ST=$(CMDSRC)/st1.s $(CMDSRC)/st2.s $(CMDSRC)/st3.s $(CMDSRC)/st4.s $(CMDSRC)/fop.s $(CMDSRC)/st5.s $(CMDSRC)/st6.s $(CMDSRC)/st7.s
+$(BINDIR)/st: $(ST)
+	$(AS) $(ASARGS) -o $(BINDIR)/st $(ST)
 
 $(BINDIR)/un: $(CMDSRC)/un.s
 	$(AS) $(ASARGS) -o $(BINDIR)/un $(CMDSRC)/un.s

--- a/build/proto
+++ b/build/proto
@@ -59,6 +59,7 @@ dd           drwr- -1 4
         tm       frwr- -1 bin/tm
         ttt      frwr- -1 bin/ttt
         dttt     l---- -1
+        st       frwr- -1 bin/st
         un       frwr- -1 bin/un
 	$
     ken      drwr- 12


### PR DESCRIPTION
The naive order of the assembly files given to the assembler was to
put the st?.s files first followed by fop.s at the end. This caused
Space Travel to crash, why that happend is explained below.

st1.s through st5.s contain code, while st6. and st7.s contain
constants and data storage respectively. The order of the given
assembler files meant that the code st?.s ended up at 010000 onwards,
while the code in fop.s ended up after the data storage defined in
st7.s. In particular the function fmp ended up immediately after dspl.

At the end of st7.s there is a display list, dspl. At runtime this
list is pointed to by the clistp variable stored at the auto-indexing
memory register at address 017. Auto-indexing means that the pointer
will be incremented after use. However the display list dspl does not
reserve memory for the entire list, instead it assumes that the memory
immediately after dpsl is unused. This conflicts with storing fmp from
fop.s immediately after st7.s!

Despite this conflict the first few frames of space travel could be
rendered because clistp was never referenced. By the time it was
referenced it changed the code in fmp to invalid code. At a later
stage when fmp was called the program crashed.

The solution I chose is to reorder the files at the command-line given
to the assembler; specifically I opted to put fop.s after all the code
in st1.s though st4.s.

This means that Space Travel now runs without crashing!