### PR TITLE
as7: accept (decimal) digits in octal constants, like as.s does!

### DIFF
--- a/tools/as7
+++ b/tools/as7
@@ -514,7 +514,11 @@ sub parse_expression {
 	    my $value = $1;
 	    printf "\tfound constant: $value\n" if ($debug);
 	    if ( $value =~ m{^0} ) {
-		$syllable = oct($value);
+		# PLB 2020-10-05: behave like as.s
+		$syllable = 0;
+		for my $digit (split(//, $value)) {
+		    $syllable = $syllable * 010 + ord($digit) - ord('0');
+		}
 	    }
 	    else {
 		$syllable = $value + 0;


### PR DESCRIPTION
Alternative to changing "bad" octal constants in source files, such as one in st7.s:
https://github.com/DoctorWkt/pdp7-unix/pull/224