### PR TITLE
Fix typos in character table.

### DIFF
--- a/src/other/chrtbl.s
+++ b/src/other/chrtbl.s
@@ -17,8 +17,8 @@ c8; c9; colon; semcln; less; equal; great; quest
 at; ca; cb; cc; cd; ce; cf; cg
 ch; ci; cj; ck; cl; cm; cn; co
 cp; cq; cr; cs; ct; cu; cv; cw
-cx; cy cz; lbk; bsla; rbk; cmflx; under
+cx; cy; cz; lbk; bsla; rbk; cmflx; under
 accr; la; lb; lc; ld; le; lf; lg
 lh; li; lj; lk; ll; lm; ln; lo
 lp; lq; lr; ls; lt; lu; lv; lw
-lx; ly lz; lbr; or; rbr; tild; null
+lx; ly; lz; lbr; or; rbr; tild; null


### PR DESCRIPTION
Without this the dispatch word for all characters after capital X will be offset by one. This prevents the font from being used in GRAPHIC-2 emulation.