### PR TITLE
Support for OpenBSD and adJ. Closes #228

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -9,7 +9,7 @@ MKFS=../tools/mkfs7
 A7OUT=../tools/a7out 
 FSCK=../tools/fsck7
 CCARGS=-Wno-multichar -Wno-implicit
-PDP7=pdp7
+PDP7?=pdp7
 
 # source dirs
 SYSSRC=../src/sys

--- a/build/os.mk
+++ b/build/os.mk
@@ -9,6 +9,10 @@ ifeq ($(UNAME), Darwin)
 else 
 ifeq ($(UNAME), FreeBSD)
 	UNAME=FREEBSD
+else 
+ifeq ($(UNAME), OpenBSD)
+	UNAME=OPENBSD
+endif
 endif
 endif
 endif
@@ -23,6 +27,10 @@ ifeq ($(UNAME), FREEBSD)
 # FreeBSD
 	CC=cc
 	MAKE=gmake
+ifeq ($(UNAME), OPENBSD)
+# OpenBSD
+	CC=cc
+	MAKE=gmake
 else
 ifeq ($(UNAME), DARWIN)
 # Mac OS X
@@ -30,6 +38,7 @@ ifeq ($(UNAME), DARWIN)
 	MAKE=make
 else
 	$(error "Unknown OS: " $(UNAME))
+endif
 endif
 endif
 endif


### PR DESCRIPTION
Closes #228.

I could use with the current version of simh this way:

1. Compile pdp7 
```
$ doas pkg_add gcc
$ egcc -v
Using built-in specs.
COLLECT_GCC=egcc
COLLECT_LTO_WRAPPER=/usr/local/libexec/gcc/x86_64-unknown-openbsd6.8/8.4.0/lto-wrapper
Target: x86_64-unknown-openbsd6.8
Configured with: /usr/obj/ports/gcc-8.4.0/gcc-8.4.0/configure --with-stage1-ldflags=-L/usr/obj/ports/gcc-8.4.0/bootstrap/lib --verbose --program-transform-name=
's,^,e,' --disable-nls --with-system-zlib --disable-libmudflap --disable-libgomp --disable-libssp --disable-tls --with-gnu-ld --with-gnu-as --enable-threads=pos
ix --enable-wchar_t --with-gmp=/usr/local --enable-languages=c,c++,fortran,objc,ada --disable-libstdcxx-pch --enable-default-ssp --enable-default-pie --without-
isl --enable-cpp --prefix=/usr/local --sysconfdir=/etc --mandir=/usr/local/man --infodir=/usr/local/info --localstatedir=/var --disable-silent-rules --disable-g
tk-doc
Thread model: posix
gcc version 8.4.0 (GCC) 
$ git clone git@github.com:simh/simh.git
lib paths are: /usr/lib /usr/X11R6/lib /usr/local/lib                                                                                                           
include paths are:  /usr/local/lib/gcc/x86_64-unknown-openbsd6.8/8.4.0/include /usr/local/lib/gcc/x86_64-unknown-openbsd6.8/8.4.0/include-fixed /usr/include /us
r/local/include                                                                                                                                                 
using libm: /usr/lib/libm.a                                                                                                                                     
using libpthread: /usr/lib/libpthread.a /usr/include/pthread.h
using libpcre: /usr/local/lib/libpcre.a /usr/local/include/pcre.h
using semaphore: /usr/include/semaphore.h       
using libdl: /usr/include/dlfcn.h
using libpng: /usr/local/lib/libpng.a /usr/local/include/png.h                                                                                                  
using zlib: /usr/lib/libz.a /usr/include/zlib.h                                                                                                                 
using mman: /usr/include/sys/mman.h                                                                                                                             
using libSDL2: /usr/local/include/SDL2/SDL.h                                                                                                                    
***                                                                                                                                                             
*** pdp7 Simulator being built with:                                                                                                                            
*** - compiler optimizations and no debugging support. GCC Version: 8.4.0.                                                                                      
*** - video capabilities provided by libSDL2 (Simple Directmedia Layer).                                                                                        
*** - Per simulator tests will be run.                                                                                                                          
***
***                                                                             
*** git commit id is e3572e1a9f149e8df5cf3482ca4cce47ae9274aa.   
*** git commit time is 2020-11-02T16:42:56-0800.
***                              
egcc -std=gnu99 -U__STRICT_ANSI__  -O2 -finline-functions -fgcse-after-reload -fpredictive-commoning -fipa-cp-clone -fno-unsafe-loop-optimizations -fno-strict-o
verflow -DSIM_GIT_COMMIT_ID=e3572e1a9f149e8df5cf3482ca4cce47ae9274aa -DSIM_GIT_COMMIT_TIME=2020-11-02T16:42:56-0800  -DSIM_COMPILER="GCC Version: 8.4.0" -DSIM_B
UILD_TOOL=simh-makefile -I . -D_GNU_SOURCE -I/usr/local/include -DUSE_READER_THREAD -DSIM_ASYNCH_IO  -DHAVE_PCRE_H -DHAVE_SEMAPHORE -DHAVE_SYS_IOCTL -DHAVE_DLOP
EN=so -DHAVE_UTIME -DHAVE_LIBPNG -DHAVE_ZLIB -DHAVE_GLOB -DHAVE_SHM_OPEN  ./PDP18B/pdp18b_dt.c ./PDP18B/pdp18b_drm.c ./PDP18B/pdp18b_cpu.c ./PDP18B/pdp18b_lp.c 
./PDP18B/pdp18b_mt.c ./PDP18B/pdp18b_rf.c ./PDP18B/pdp18b_rp.c ./PDP18B/pdp18b_stddev.c ./PDP18B/pdp18b_sys.c ./PDP18B/pdp18b_rb.c ./PDP18B/pdp18b_tt1.c ./PDP18
B/pdp18b_fpp.c ./PDP18B/pdp18b_g2tty.c ./PDP18B/pdp18b_dr15.c ./PDP18B/pdp18b_dpy.c ./display/display.c ./display/sim_ws.c ./display/type340.c ./scp.c ./sim_con
sole.c ./sim_fio.c ./sim_timer.c ./sim_sock.c ./sim_tmxr.c ./sim_ether.c ./sim_tape.c ./sim_disk.c ./sim_serial.c ./sim_video.c ./sim_imd.c ./sim_card.c -DPDP7 
-I ./PDP18B -DUSE_DISPLAY -DHAVE_LIBSDL -DUSE_SIM_VIDEO `/usr/local/bin/sdl2-config --cflags` `/usr/local/bin/sdl2-config --libs` -DDISPLAY_TYPE=DIS_TYPE30 -DPI
X_SCALE=RES_HALF -o BIN/pdp7 -L/usr/lib -L/usr/X11R6/lib -L/usr/local/lib -lm -lpthread -lpcre -L/usr/local/lib/ -lpng -lz
BIN/pdp7 RegisterSanityCheck  </dev/null 
 Running internal register sanity checks on PDP-7 simulator.
*** Good Registers in PDP-7 simulator.
```

2. Compiling pdp7-unix

```
$ cd simh
$ GCC=egcc gmake pdp7

$ cd pdp7-unix
$ gmake
cd build && gmake all
gmake[1]: se entra en el directorio '/home/vtamara/comp/unix/pdp7-unix0/pdp7-unix-vtamara/build'
mkdir -p bin
../tools/as7 --format=ptr -o bin/adm ../src/cmd/adm.s
I
II
../src/cmd/adm.s
../tools/as7 --format=ptr -o bin/apr ../src/cmd/apr.s
I
II
../src/cmd/apr.s
../tools/as7 --format=ptr -o bin/as ../src/cmd/as.s
I
II
../src/cmd/as.s
../tools/as7 --format=ptr -o bin/cas ../src/cmd/cas.s
I
II
../src/cmd/cas.s
../tools/as7 --format=ptr -o bin/cat ../src/cmd/cat.s
I
II
../src/cmd/cat.s
../tools/as7 --format=ptr -o bin/check ../src/cmd/check.s
I
II
../src/cmd/check.s
../tools/as7 --format=ptr -o bin/chmod ../src/cmd/chmod.s
I
II
../src/cmd/chmod.s
../tools/as7 --format=ptr -o bin/chown ../src/cmd/chown.s
I
II
../src/cmd/chown.s
../tools/as7 --format=ptr -o bin/chrm ../src/cmd/chrm.s
I
II
../src/cmd/chrm.s
../tools/as7 --format=ptr -o bin/cp ../src/cmd/cp.s
I
II
../src/cmd/cp.s
../tools/as7 --format=ptr -o bin/db ../src/cmd/db.s
I
II
../src/cmd/db.s
../src/cmd/db.s:1165: Warning: Global label o151 multiply defined
../src/cmd/db.s:1175: Warning: Global label dm6 multiply defined
../src/cmd/db.s:1207: Warning: Global label nlbufp multiply defined
../src/cmd/db.s:1209: Warning: Global label dm6 multiply defined
../src/cmd/db.s:1222: Warning: Global label nlbufp multiply defined
../src/cmd/db.s:1232: Warning: Global label o151 multiply defined
../src/cmd/db.s:1238: Warning: Global label nlbufp multiply defined
../tools/as7 --format=ptr -o bin/ds ../src/cmd/ds.s
I
II
../src/cmd/ds.s
../tools/as7 --format=ptr -o bin/dskres ../src/cmd/dskres.s ../src/cmd/dskio.s ../src/sys/sop.s
I
II
../src/cmd/dskres.s
../src/cmd/dskio.s
../src/sys/sop.s
../tools/as7 --format=ptr -o bin/dsksav ../src/cmd/dsksav.s ../src/cmd/dskio.s ../src/sys/sop.s
I
II
../src/cmd/dsksav.s
../src/cmd/dskio.s
../src/sys/sop.s
../tools/as7 --format=ptr -o bin/dsw ../src/cmd/dsw.s
I
II
../src/cmd/dsw.s
../tools/as7 --format=ptr -o bin/ed ../src/cmd/ed1.s ../src/cmd/ed2.s
I
II
../src/cmd/ed1.s
../src/cmd/ed2.s
../tools/as7 --format=ptr -o bin/init ../src/cmd/init.s
I
II
../src/cmd/init.s
../tools/as7 --format=ptr -o bin/ln ../src/cmd/ln.s
I
II
../src/cmd/ln.s
../tools/as7 --format=ptr -o bin/ls ../src/cmd/ls.s
I
II
../src/cmd/ls.s
../tools/as7 --format=ptr -o bin/moo ../src/cmd/moo.s
I
II
../src/cmd/moo.s
../tools/as7 --format=ptr -o bin/nm ../src/cmd/nm.s
I
II
../src/cmd/nm.s
../tools/as7 --format=ptr -o bin/p ../src/cmd/p1.s ../src/cmd/p2.s ../src/cmd/p3.s ../src/cmd/p4.s ../src/cmd/p5.s
I
II
../src/cmd/p1.s
../src/cmd/p2.s
../src/cmd/p3.s
../src/cmd/p4.s
../src/cmd/p5.s
../tools/as7 --format=ptr -o bin/rm ../src/cmd/rm.s
I
II
../src/cmd/rm.s
../tools/as7 --format=ptr -o bin/rn ../src/cmd/rn.s
I
II
../src/cmd/rn.s
../tools/as7 --format=ptr -o bin/roff ../src/cmd/roff.s
I
II
../src/cmd/roff.s
../tools/as7 --format=ptr -o bin/salv ../src/cmd/salv.s
I
II
../src/cmd/salv.s
../tools/as7 --format=ptr -o bin/sh ../src/cmd/sh.s
I
II
../src/cmd/sh.s
../tools/as7 --format=ptr -o bin/st ../src/cmd/st1.s ../src/cmd/st2.s ../src/cmd/st3.s ../src/cmd/st4.s ../src/cmd/fop.s ../src/cmd/st5.s ../src/cmd/st6.s ../src/cmd/st7.s
I
II
../src/cmd/st1.s
../src/cmd/st2.s
../src/cmd/st3.s
../src/cmd/st4.s
../src/cmd/fop.s
../src/cmd/fop.s:5: Warning: Global label q multiply defined
../src/cmd/fop.s:82: Warning: Global label q multiply defined
../src/cmd/fop.s:173: Warning: Global label q multiply defined
../src/cmd/fop.s:280: Warning: Global label q multiply defined
../src/cmd/fop.s:308: Warning: Global label q multiply defined
../src/cmd/fop.s:350: Warning: Global label q multiply defined
../src/cmd/fop.s:374: Warning: Global label q multiply defined
../src/cmd/fop.s:410: Warning: Global label q multiply defined
../src/cmd/fop.s:442: Warning: Global label q multiply defined
../src/cmd/fop.s:536: Warning: Global label q multiply defined
../src/cmd/fop.s:550: Warning: Global label q multiply defined
../src/cmd/fop.s:565: Warning: Global label q multiply defined
../src/cmd/fop.s:573: Warning: Global label q multiply defined
../src/cmd/fop.s:603: Warning: Global label q multiply defined
../src/cmd/fop.s:646: Warning: Global label q multiply defined
../src/cmd/fop.s:701: Warning: Global label q multiply defined
../src/cmd/fop.s:774: Warning: Global label ftmp1 multiply defined
../src/cmd/fop.s:775: Warning: Global label ftmp2 multiply defined
../src/cmd/fop.s:790: Warning: Global label o377777 multiply defined
../src/cmd/fop.s:792: Warning: Global label o377777 multiply defined
../src/cmd/fop.s:797: Warning: Global label dm1 multiply defined
../src/cmd/st5.s
../src/cmd/st6.s
../src/cmd/st7.s
../src/cmd/st7.s:19: Warning: Global label dm1 multiply defined
../src/cmd/st7.s:110: Warning: Global label ftmp1 multiply defined
../src/cmd/st7.s:111: Warning: Global label ftmp2 multiply defined
../tools/as7 --format=ptr -o bin/stat ../src/cmd/stat.s
I
II
../src/cmd/stat.s
../tools/as7 --format=ptr -o bin/tm ../src/cmd/tm.s
I
II
../src/cmd/tm.s
../tools/as7 --format=ptr -o bin/ttt ../src/cmd/ttt1.s ../src/cmd/ttt2.s
I
II
../src/cmd/ttt1.s
../src/cmd/ttt2.s
../tools/as7 --format=ptr -o bin/un ../src/cmd/un.s
I
II
../src/cmd/un.s
cc -Wno-multichar -Wno-implicit -o b ../tools/b.c
../tools/b.c:54:1: warning: non-void function does not return a value [-Wreturn-type]
}
^
../tools/b.c:57:1: warning: non-void function does not return a value [-Wreturn-type]
}
^
../tools/b.c:115:14: warning: using the result of an assignment as a condition without parentheses [-Wparentheses]
  while (*ns = *sp) {
         ~~~~^~~~~
../tools/b.c:115:14: note: place parentheses around the assignment to silence this warning
  while (*ns = *sp) {
             ^
         (        )
../tools/b.c:115:14: note: use '==' to turn this assignment into an equality comparison
  while (*ns = *sp) {
             ^
             ==
../tools/b.c:770:1: warning: non-void function does not return a value [-Wreturn-type]
}
^
../tools/b.c:778:1: warning: non-void function does not return a value [-Wreturn-type]
}
^
../tools/b.c:786:1: warning: non-void function does not return a value [-Wreturn-type]
}
^
../tools/b.c:793:1: warning: non-void function does not return a value [-Wreturn-type]
}
^
../tools/b.c:801:1: warning: non-void function does not return a value [-Wreturn-type]
}
^
../tools/b.c:809:1: warning: non-void function does not return a value [-Wreturn-type]
}
^
../tools/b.c:816:1: warning: non-void function does not return a value [-Wreturn-type]
}
^
../tools/b.c:822:11: warning: | has lower precedence than ==; == will be evaluated first [-Wparentheses]
  if (eof | nerror==20) {
          ^~~~~~~~~~~~
../tools/b.c:822:11: note: place parentheses around the '==' expression to silence this warning
  if (eof | nerror==20) {
          ^
            (         )
../tools/b.c:822:11: note: place parentheses around the | expression to evaluate it first
  if (eof | nerror==20) {
      ~~~~^~~~~~~~
11 warnings generated.
./b ../src/other/b.b b.s
../tools/as7 --format=ptr -o bin/b ../src/cmd/bl.s b.s ../src/cmd/bi.s
I
II
../src/cmd/bl.s
b.s
../src/cmd/bi.s
rm b b.s
../tools/as7 --format=ptr -o bin/date ../src/other/wktdate.s
I
II
../src/other/wktdate.s
../tools/as7 --format=ptr -o bin/mv ../src/other/wktmv.s
I
II
../src/other/wktmv.s
../tools/as7 --format=ptr -o bin/od ../src/other/wktod.s
I
II
../src/other/wktod.s
../tools/as7 -f ptr  -o a.out ../src/sys/sop.s ../src/sys/sop.s ../src/sys/s1.s ../src/sys/s2.s ../src/sys/s3.s ../src/sys/s4.s ../src/sys/s5.s ../src/sys/s6.s ../src/sys/s7.s ../src/sys/s8.s
I
II
../src/sys/sop.s
../src/sys/sop.s
../src/sys/s1.s
../src/sys/s2.s
../src/sys/s3.s
../src/sys/s4.s
../src/sys/s5.s
../src/sys/s6.s
../src/sys/s7.s
../src/sys/s8.s
../tools/as7 -n -f list -o a.lst ../src/sys/sop.s ../src/sys/sop.s ../src/sys/s1.s ../src/sys/s2.s ../src/sys/s3.s ../src/sys/s4.s ../src/sys/s5.s ../src/sys/s6.s ../src/sys/s7.s ../src/sys/s8.s
I
II
../src/sys/sop.s
../src/sys/sop.s
../src/sys/s1.s
../src/sys/s2.s
../src/sys/s3.s
../src/sys/s4.s
../src/sys/s5.s
../src/sys/s6.s
../src/sys/s7.s
../src/sys/s8.s
../tools/as7 -f rim -o boot.rim ../src/sys/sop.s ../src/other/pbboot.s
I
II
../src/sys/sop.s
../src/other/pbboot.s
rm -f cas.in
ln -s ../src/sys/cas.in .
../tools/a7out  bin/cas cas.out cas.in
rm -f cas.in
../tools/as7 -f ptr --no-label-warnings -o chrtbl.out ../src/other/chrtbl.s cas.out
I
II
../src/other/chrtbl.s
cas.out
../tools/mkfs7 -k a.out -c chrtbl.out proto
i-num 1 already allocated, ignoring this
i-num 3 already allocated, ignoring this
../tools/fsck7 image.fs
Directory dd, i-node 4
   4 drwr-  6 777    56 dd/dd
   4 drwr-  6 777    56 dd/..
   1 srwrw  1 777     0 dd/core
   3 drwr-  5 777   384 dd/system
  51 drwr-  2  12   120 dd/ken
  64 drwr-  2  14    88 dd/dmr
  73 drwr-  2  15    88 dd/doug

Directory dd/system, i-node 3
   4 drwr-  6 777    56 dd/system/dd
   3 drwr-  5 777   384 dd/system/..
   6 irwr-  1 777     0 dd/system/ttyin
   7 irwr-  1 777     0 dd/system/keyboard
   8 irwr-  1 777     0 dd/system/pptin
  11 irwr-  1 777     0 dd/system/ttyout
  12 irwr-  1 777     0 dd/system/display
  13 irwr-  1 777     0 dd/system/pptout
  14 srw--  1 777    38 dd/system/password
  15 lrwr-  1 777   729 dd/system/adm
  16 lrwr-  1 777   874 dd/system/apr
  17 lrwr-  1 777  1018 dd/system/as
  18 lrwr-  1 777  3665 dd/system/b
  19 lrwr-  1 777  1023 dd/system/cas
  20 srwr-  1 777   268 dd/system/cat
  21 srwr-  1 777   321 dd/system/check
  22 srwr-  1 777    71 dd/system/chmod
  23 srwr-  1 777    71 dd/system/chown
  24 srwr-  1 777    46 dd/system/chrm
  25 srwr-  1 777   105 dd/system/cp
  26 srwr-  1 777   197 dd/system/date
  27 lrwr-  1 777  1168 dd/system/db
  28 lrwr-  1 777   500 dd/system/ds
  29 srwr-  1 777    92 dd/system/dskres
  30 srwr-  1 777    92 dd/system/dsksav
  31 srwr-  1 777    41 dd/system/dsw
  32 lrwr-  1 777  1126 dd/system/ed
  33 srwr-  1 777   300 dd/system/init
  34 srwr-  2 777   113 dd/system/ln
  34 srwr-  2 777   113 dd/system/link
  35 srwr-  2 777   313 dd/system/ls
  35 srwr-  2 777   313 dd/system/list
  36 lrwr-  1 777   568 dd/system/moo
  37 srwr-  1 777    41 dd/system/mv
  38 srwr-  1 777   347 dd/system/nm
  39 srwr-  1 777   108 dd/system/od
  40 lrwr-  1 777   901 dd/system/p
  41 srwr-  1 777    31 dd/system/rm
  42 srwr-  1 777    63 dd/system/rn
  43 lrwr-  1 777   832 dd/system/roff
  44 srwr-  1 777   283 dd/system/salv
  45 srwr-  1 777   386 dd/system/sh
  46 srwr-  1 777   100 dd/system/stat
  47 srwr-  1 777    79 dd/system/tm
  48 lrwr-  2 777  1383 dd/system/ttt
  48 lrwr-  2 777  1383 dd/system/dttt
  49 lrwr-  1 777  3014 dd/system/st
  50 srwr-  1 777    53 dd/system/un

Directory dd/ken, i-node 51
   4 drwr-  6 777    56 dd/ken/dd
  51 drwr-  2  12   120 dd/ken/..
   3 drwr-  5 777   384 dd/ken/system
  52 lrwr-  1  12  1861 dd/ken/sop.s
  53 lrwr-  1  12  3090 dd/ken/s1.s
  54 lrwr-  1  12  5523 dd/ken/s2.s
  55 lrwr-  1  12  4738 dd/ken/s3.s
  56 lrwr-  1  12  5375 dd/ken/s4.s
  57 lrwr-  1  12  4263 dd/ken/s5.s
  58 lrwr-  1  12  5067 dd/ken/s6.s
  59 lrwr-  1  12  4719 dd/ken/s7.s
  60 lrwr-  1  12  3383 dd/ken/s8.s
  61 lrwr-  1  12   479 dd/ken/maksys.s
  62 srwr-  1  12   202 dd/ken/trysys.s
  63 srwr-  1  12    78 dd/ken/sys.rc

Directory dd/dmr, i-node 64
   4 drwr-  6 777    56 dd/dmr/dd
  64 drwr-  2  14    88 dd/dmr/..
   3 drwr-  5 777   384 dd/dmr/system
  65 lrwr-  1  14 11598 dd/dmr/as.s
  66 lrwr-  1  14   636 dd/dmr/op.s
  67 srwr-  1  14    88 dd/dmr/b_readme
  68 lrwr-  1  14  2197 dd/dmr/bi.s
  69 lrwr-  1  14  1084 dd/dmr/bl.s
  70 lrwr-  1  14  7587 dd/dmr/db.s
  71 srwr-  1  14    59 dd/dmr/hello.b
  72 lrwr-  1  14  6876 dd/dmr/b.b

Directory dd/doug, i-node 73
   4 drwr-  6 777    56 dd/doug/dd
  73 drwr-  2  15    88 dd/doug/..
   3 drwr-  5 777   384 dd/doug/system
  74 srwr-  1  15   404 dd/doug/t1.s
  75 lrwr-  1  15  2300 dd/doug/t2.s
  76 lrwr-  1  15  1545 dd/doug/t3.s
  77 lrwr-  1  15   694 dd/doug/t4.s
  78 lrwr-  1  15   692 dd/doug/t5.s
  79 lrwr-  1  15  1036 dd/doug/t6.s
  80 lrwr-  1  15   689 dd/doug/t7.s
  81 srwr-  1  15   418 dd/doug/t8.s

gmake[1]: se sale del directorio '/home/vtamara/comp/unix/pdp7-unix0/pdp7-unix-vtamara/build'
                                                               
$ cd build
$ gmake
mkdir -p bin
../tools/mkfs7 -k a.out -c chrtbl.out proto
i-num 1 already allocated, ignoring this
i-num 3 already allocated, ignoring this
../tools/fsck7 image.fs
Directory dd, i-node 4
   4 drwr-  6 777    56 dd/dd
   4 drwr-  6 777    56 dd/..
   1 srwrw  1 777     0 dd/core
   3 drwr-  5 777   384 dd/system
  51 drwr-  2  12   120 dd/ken
  64 drwr-  2  14    88 dd/dmr
  73 drwr-  2  15    88 dd/doug

Directory dd/system, i-node 3
   4 drwr-  6 777    56 dd/system/dd
   3 drwr-  5 777   384 dd/system/..
   6 irwr-  1 777     0 dd/system/ttyin
   7 irwr-  1 777     0 dd/system/keyboard
   8 irwr-  1 777     0 dd/system/pptin
  11 irwr-  1 777     0 dd/system/ttyout
  12 irwr-  1 777     0 dd/system/display
  13 irwr-  1 777     0 dd/system/pptout
  14 srw--  1 777    38 dd/system/password
  15 lrwr-  1 777   729 dd/system/adm
  16 lrwr-  1 777   874 dd/system/apr
  17 lrwr-  1 777  1018 dd/system/as
  18 lrwr-  1 777  3665 dd/system/b
  19 lrwr-  1 777  1023 dd/system/cas
  20 srwr-  1 777   268 dd/system/cat
  21 srwr-  1 777   321 dd/system/check
  22 srwr-  1 777    71 dd/system/chmod
  23 srwr-  1 777    71 dd/system/chown
  24 srwr-  1 777    46 dd/system/chrm
  25 srwr-  1 777   105 dd/system/cp
  26 srwr-  1 777   197 dd/system/date
  27 lrwr-  1 777  1168 dd/system/db
  28 lrwr-  1 777   500 dd/system/ds
  29 srwr-  1 777    92 dd/system/dskres
  30 srwr-  1 777    92 dd/system/dsksav
  31 srwr-  1 777    41 dd/system/dsw
  32 lrwr-  1 777  1126 dd/system/ed
  33 srwr-  1 777   300 dd/system/init
  34 srwr-  2 777   113 dd/system/ln
  34 srwr-  2 777   113 dd/system/link
  35 srwr-  2 777   313 dd/system/ls
  35 srwr-  2 777   313 dd/system/list
  36 lrwr-  1 777   568 dd/system/moo
  37 srwr-  1 777    41 dd/system/mv
  38 srwr-  1 777   347 dd/system/nm
  39 srwr-  1 777   108 dd/system/od
  40 lrwr-  1 777   901 dd/system/p
  41 srwr-  1 777    31 dd/system/rm
  42 srwr-  1 777    63 dd/system/rn
  43 lrwr-  1 777   832 dd/system/roff
  44 srwr-  1 777   283 dd/system/salv
  45 srwr-  1 777   386 dd/system/sh
  46 srwr-  1 777   100 dd/system/stat
  47 srwr-  1 777    79 dd/system/tm
  48 lrwr-  2 777  1383 dd/system/ttt
  48 lrwr-  2 777  1383 dd/system/dttt
  49 lrwr-  1 777  3014 dd/system/st
  50 srwr-  1 777    53 dd/system/un

Directory dd/ken, i-node 51
   4 drwr-  6 777    56 dd/ken/dd
  51 drwr-  2  12   120 dd/ken/..
   3 drwr-  5 777   384 dd/ken/system
  52 lrwr-  1  12  1861 dd/ken/sop.s
  53 lrwr-  1  12  3090 dd/ken/s1.s
  54 lrwr-  1  12  5523 dd/ken/s2.s
  55 lrwr-  1  12  4738 dd/ken/s3.s
  56 lrwr-  1  12  5375 dd/ken/s4.s
  57 lrwr-  1  12  4263 dd/ken/s5.s
  58 lrwr-  1  12  5067 dd/ken/s6.s
  59 lrwr-  1  12  4719 dd/ken/s7.s
  60 lrwr-  1  12  3383 dd/ken/s8.s
  61 lrwr-  1  12   479 dd/ken/maksys.s
  62 srwr-  1  12   202 dd/ken/trysys.s
  63 srwr-  1  12    78 dd/ken/sys.rc

Directory dd/dmr, i-node 64
   4 drwr-  6 777    56 dd/dmr/dd
  64 drwr-  2  14    88 dd/dmr/..
   3 drwr-  5 777   384 dd/dmr/system
  65 lrwr-  1  14 11598 dd/dmr/as.s
  66 lrwr-  1  14   636 dd/dmr/op.s
  67 srwr-  1  14    88 dd/dmr/b_readme
  68 lrwr-  1  14  2197 dd/dmr/bi.s
  69 lrwr-  1  14  1084 dd/dmr/bl.s
  70 lrwr-  1  14  7587 dd/dmr/db.s
  71 srwr-  1  14    59 dd/dmr/hello.b
  72 lrwr-  1  14  6876 dd/dmr/b.b

Directory dd/doug, i-node 73
   4 drwr-  6 777    56 dd/doug/dd
  73 drwr-  2  15    88 dd/doug/..
   3 drwr-  5 777   384 dd/doug/system
  74 srwr-  1  15   404 dd/doug/t1.s
  75 lrwr-  1  15  2300 dd/doug/t2.s
  76 lrwr-  1  15  1545 dd/doug/t3.s
  77 lrwr-  1  15   694 dd/doug/t4.s
  78 lrwr-  1  15   692 dd/doug/t5.s
  79 lrwr-  1  15  1036 dd/doug/t6.s
  80 lrwr-  1  15   689 dd/doug/t7.s
  81 srwr-  1  15   418 dd/doug/t8.s

```

3. Run pdp7-unix
```
$ PDP7=../../simh/BIN/pdp7 gmake run
../../simh/BIN/pdp7 unixv0.simh

PDP-7 simulator V4.0-0 Current        git commit id: e3572e1a
CPU     idle disabled
        8KW, EAE
/home/vtamara/comp/unix/pdp7-unix0/pdp7-unix-vtamara/build/unixv0.simh-13> att rb image.fs
RB: buffering file in memory
/home/vtamara/comp/unix/pdp7-unix0/pdp7-unix-vtamara/build/unixv0.simh-17> att -U g2in 12345
Listening on port 12345
PDP-7 simulator configuration

CPU     idle disabled
CLK     60Hz, devno=00
PTR     devno=01
PTP     devno=02
TTI     devno=03
TTO     devno=04
LPT     disabled
DRM     disabled
RB      devno=71
DT      disabled
G2OUT   devno=05
G2IN    devno=43-44
DPY     disabled


login: 
Simulation stopped, PC: 01057 (DAC 5525)
sim> q
Goodbye
RB: writing buffer to file
```

