### PR TITLE
Add standings file to get moo running.

### DIFF
--- a/build/proto
+++ b/build/proto
@@ -76,6 +76,7 @@ dd           drwr- -1 4
       maksys.s   frwr- 12 ../src/sys/maksys.s
       trysys.s   frwr- 12 ../src/sys/trysys.s
       sys.rc     frwr- 12 fs/sys.rc
+      moostat    frwr- 12 fs/moostat
       $
     dmr        drwr- 14
       system   l----  3


### PR DESCRIPTION
Recently Wordle has piqued the interest of many (like me):
https://www.powerlanguage.co.uk/wordle/

A recent video by Tech Tangents links Wordle to Master Mind
and also mentions it being based on Bulls and Cows or Moo:
https://www.youtube.com/watch?v=rLUmER9dn9A&t=141s
https://en.wikipedia.org/wiki/Bulls_and_Cows#The_numerical_version

Judging by the assembler listing I thought moo.s might
be an implementation of the game for PDP-7 UNIX. I
debugged the game deduced why it exits early.

The game statistics are saved in the file moostat.
Prior to this commit there was no such file which
caused moo to exit immediately at start. Now, once
the file exists, the game can run successfully.

This is how to play the game:

1. after having logged in as ken, enter "moo" ENTER at prompt
2. moo asks "wru?" which means "who are you?"
3. answer "ken" ENTER
4. moo says "name not found; enter?"
5. answer "y" to participate in the game
6. moo says "ready?"
7a. answer "s" to see the current standings between participants listing name, number of games, average guesses, average time
7b. answer "a" to see your average, showing number of games, average guesses and average time
7c. answer "r" to reset the game from step 2 above
7d. answer "q" to quit the game if you wish
8. answer "y" to begin the game
9. moo generates a secret number that you must guess
10. enter a four digit number like "2874" and press ENTER
11. if your guess is correct, moo says "g=<number of guesses> t=<time in some unit>", goto step 6
11. if your guess is not correct, moo says "bc=" followed by two numbers
12. 1st digit is the number of correct digits in the correct place in your guess
13. 2nd digit is the number of correct digits in the wrong place in your guess
14. goto 10