### PR TITLE
Change ald to assemble successfully and include it in build.

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -112,6 +112,7 @@ dirs:
 # PLEASE KEEP IN ALPHABETICAL ORDER!
 cmd:	dirs \
 	$(BINDIR)/adm \
+	$(BINDIR)/ald \
 	$(BINDIR)/apr \
 	$(BINDIR)/as \
 	$(BINDIR)/cas \
@@ -151,6 +152,9 @@ altcmd: dirs cmd \
 
 $(BINDIR)/adm: $(CMDSRC)/adm.s
 	$(AS) $(ASARGS) -o $(BINDIR)/adm $(CMDSRC)/adm.s
+
+$(BINDIR)/ald: $(CMDSRC)/ald.s
+	$(AS) $(ASARGS) -o $(BINDIR)/ald $(CMDSRC)/ald.s
 
 $(BINDIR)/apr: $(CMDSRC)/apr.s
 	$(AS) $(ASARGS) -o $(BINDIR)/apr $(CMDSRC)/apr.s

--- a/build/proto
+++ b/build/proto
@@ -23,6 +23,7 @@ dd           drwr- -1 4
         pptout   irwr- -1 13
         password frw-- -1 fs/password
         adm      frwr- -1 bin/adm
+        ald      frwr- -1 bin/ald
         apr      frwr- -1 bin/apr
         as       frwr- -1 bin/as
         b        frwr- -1 bin/b

--- a/src/cmd/ald.s
+++ b/src/cmd/ald.s
@@ -79,7 +79,7 @@ cloop:
    jmp 1f
    dac 0f
    lac fo
-   sys write; obuf; 0;..
+   sys write; obuf; 0:..
 1:
    lac fo
    sys close
@@ -228,6 +228,16 @@ putword: 0
    dac opt
    jmp putword i
    jmp putword i
+
+ferror:
+   lac buf
+   dac 1f
+   lac d1
+   sys write; 1:..; 4
+   lac d1
+   sys write; 1f; 1
+   jmp loop
+1: 077012
 
 d1: 1
 d2048: 2048


### PR DESCRIPTION
While the scan of src/cmd/als.s clearly refers to ferror,
that routine is entirely missing from the scans of ald.

There are two identical ferror routines in src/cmd/adm.s and
src/cmd/apr.s printing the file name of a file that cannot be
openend.

ald calls ferror when unable to create a file. For ald to have
a similar ferror routine when creation fails appears sensible.

Therefore a similar routine is added to src/cmd/ald.s with
modifications to the variable containing the file name and
the label ferror jumps back to once done.